### PR TITLE
fix: resolve readiness timeout issue in ECS deployment

### DIFF
--- a/src/main/java/com/mascot/springboots3gallery/service/S3Service.java
+++ b/src/main/java/com/mascot/springboots3gallery/service/S3Service.java
@@ -109,6 +109,8 @@ public class S3Service {
             continuationToken = response.nextContinuationToken();
         } while (continuationToken != null);
 
+        allObjects.removeIf(s3Object -> s3Object.key().endsWith(".zip"));
+
         int totalElements = allObjects.size(); // Total number of objects in the bucket
 
         // Step 2: Paginate the objects based on the requested page and pageSize


### PR DESCRIPTION
- Increase readiness timeout to 5 minutes in CloudFormation template.
- Verify ALB listener ARN and fix mismatched configuration.
- Update ECS task definition to ensure proper health checks.